### PR TITLE
[feature/meethome-style-fe] 일정이 없을 때 일정만들기가 안보이는 문제 해결

### DIFF
--- a/frontend/src/Pages/Meethome/Schedule.css
+++ b/frontend/src/Pages/Meethome/Schedule.css
@@ -97,13 +97,13 @@
   display: flex;
   justify-content: center;
   font-size: 16px;
-  padding-bottom: 500px;
 }
 .noneScheduleCreate {
-  margin-top: 50px;
+  margin-top: 26px;
   display: flex;
   justify-content: center;
   border: 1px;
+  padding-bottom: 500px;
 }
 .scheduleBtn {
   border: 1px solid rgb(160, 160, 160) !important;


### PR DESCRIPTION
"일정이 없습니다"의 div 박스에 padding-bottom 값을 없어서 문제 해결함

<!-- Title: [브랜치명] 변경 내용 요약 -->

### PR Type
<!-- 해당하는 칸에 [x] 이렇게 표시하면 체크됩니다. -->

- [ ] FEAT: 새로운 기능 구현(Feature)
- [x] FIX: 버그 수정(Bugfix)
- [ ] STYLE: 포맷팅 변경(Code style update)
- [ ] REFACTOR: 코드 리팩토링(Refactoring - no functional changes, no api changes)
- [ ] TEST: 테스트 관련(Test)
- [ ] DEPLOY: 배포 관련(Deploy)
- [ ] CONF: 빌드, 환경 설정(Build)
- [ ] CHORE: 기타 작업(Other)

### Summary


### Description
<!-- 구체적인 작업 내용, 필요시 이미지 첨부 -->
- 일정이 없을 때 일정만들기 버튼이 안보이는 문제가 있었음 
- padding값을 잘못줘서 문제가 생김 
- 

### Discussion
<!-- 추후 논의할 점 -->
- 
- 

### Issue Number or Link
<!-- 예시: closes #issue-number -->

